### PR TITLE
Implement some VIF instructions

### DIFF
--- a/liborbum/src/Controller/Ee/Vpu/Vif/CVif.cpp
+++ b/liborbum/src/Controller/Ee/Vpu/Vif/CVif.cpp
@@ -76,12 +76,12 @@ int CVif::time_step(const int ticks_available)
 
                 // If the I bit is set, we need to raise an interrupt after the whole VIF packet has been processed - set a context variable.
                 /*
-				if (instruction.i())
-				{
-					auto _lock = r.ee.intc.stat.scope_lock();
-					r.ee.intc.stat.insert_field(EeIntcRegister_Stat::VIF, 1);
-				}
-				*/
+                if (instruction.i())
+                {
+                    auto _lock = r.ee.intc.stat.scope_lock();
+                    r.ee.intc.stat.insert_field(EeIntcRegister_Stat::VIF, 1);
+                }
+                */
             }
         }
     }
@@ -96,95 +96,100 @@ void CVif::INSTRUCTION_UNSUPPORTED(VifUnit_Base* unit, const VifcodeInstruction 
 }
 
 // Refer to EE Users Manual pg 103.
-void CVif::NOP(VifUnit_Base * unit, const VifcodeInstruction inst)
+void CVif::NOP(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
-	// nothing to do
+    // nothing to do
 }
 
 // Refer to EE Users Manual pg 104.
-void CVif::STCYCL(VifUnit_Base * unit, const VifcodeInstruction inst)
+void CVif::STCYCL(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
-	// Writes CODE.IMMEDIATE to CYCLE
-	uword immediate = unit->code.IMMEDIATE.extract_from(unit->code.read_uword());
-	unit->cycle.write_uword(immediate);
+    // Writes CODE.IMMEDIATE to CYCLE
+    uword immediate = unit->code.IMMEDIATE.extract_from(unit->code.read_uword());
+    unit->cycle.write_uword(immediate);
 }
 
 // Refer to EE Users Manual pg 105.
-void CVif::OFFSET(VifUnit_Base * unit, const VifcodeInstruction inst)
+void CVif::OFFSET(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
-	// VIF1 only
-	if (unit->core_id != 1) return;
+    // VIF1 only
+    if (unit->core_id != 1)
+        return;
 
-	// Clear STAT.DBF
-	uword status = 0;
-	unit->stat.write_uword(unit->stat.DBF.insert_into(unit->stat.read_uword(), status));
-	
-	// Writes the lower 10 bits of CODE.IMMEDIATE to OFST
-	uword immediate = unit->code.IMMEDIATE.extract_from(unit->code.read_uword());
-	unit->ofst.write_uword(unit->ofst.OFFSET.extract_from(immediate));
+    // Clear STAT.DBF
+    uword status = 0;
+    unit->stat.write_uword(unit->stat.DBF.insert_into(unit->stat.read_uword(), status));
 
-	// Transfer BASE to TOPS
-	unit->tops.write_uword(unit->base.read_uword());
+    // Writes the lower 10 bits of CODE.IMMEDIATE to OFST
+    uword immediate = unit->code.IMMEDIATE.extract_from(unit->code.read_uword());
+    unit->ofst.write_uword(unit->ofst.OFFSET.extract_from(immediate));
+
+    // Transfer BASE to TOPS
+    unit->tops.write_uword(unit->base.read_uword());
 }
 
 // Refer to EE Users Manual pg 106.
-void CVif::BASE(VifUnit_Base * unit, const VifcodeInstruction inst)
+void CVif::BASE(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
-	// VIF1 only
-	if (unit->core_id != 1) return;
+    // VIF1 only
+    if (unit->core_id != 1)
+        return;
 
-	// Writes the lower 10 bits of CODE.IMMEDIATE to BASE
-	uword immediate = unit->code.IMMEDIATE.extract_from(unit->code.read_uword());
-	unit->base.write_uword(unit->base.BASE.extract_from(immediate));
+    // Writes the lower 10 bits of CODE.IMMEDIATE to BASE
+    uword immediate = unit->code.IMMEDIATE.extract_from(unit->code.read_uword());
+    unit->base.write_uword(unit->base.BASE.extract_from(immediate));
 }
 
 // Refer to EE Users Manual pg 107.
-void CVif::ITOP(VifUnit_Base * unit, const VifcodeInstruction inst)
+void CVif::ITOP(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
-	uword immediate = unit->itops.ITOPS.extract_from(unit->code.read_uword());
-	unit->itops.write_uword(immediate);
+    uword immediate = unit->itops.ITOPS.extract_from(unit->code.read_uword());
+    unit->itops.write_uword(immediate);
 }
 
 // Refer to EE Users Manual pg 108.
-void CVif::STMOD(VifUnit_Base * unit, const VifcodeInstruction inst)
+void CVif::STMOD(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
-	uword immediate = unit->mode.MOD.extract_from(unit->code.read_uword());
-	unit->mode.write_uword(immediate);
+    uword immediate = unit->mode.MOD.extract_from(unit->code.read_uword());
+    unit->mode.write_uword(immediate);
 }
 
 void CVif::MSKPATH3(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
-	// VIF1 only
-	if (unit->core_id != 1) return;
+    // VIF1 only
+    if (unit->core_id != 1)
+        return;
 
-	// TODO: Implement this
+    // TODO: Implement this
 }
 
 void CVif::MARK(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
-	uword immediate = unit->mark.MARK.extract_from(unit->code.read_uword());
-	unit->mark.write_uword(immediate);
+    uword immediate = unit->mark.MARK.extract_from(unit->code.read_uword());
+    unit->mark.write_uword(immediate);
 }
 
 void CVif::FLUSHE(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
-	// TODO: Implement this
+    // TODO: Implement this
 }
 
 void CVif::FLUSH(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
-	// VIF1 only
-	if (unit->core_id != 1) return;
+    // VIF1 only
+    if (unit->core_id != 1)
+        return;
 
-	// TODO: Implement this
+    // TODO: Implement this
 }
 
 void CVif::FLUSHA(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
-	// VIF1 only
-	if (unit->core_id != 1) return;
+    // VIF1 only
+    if (unit->core_id != 1)
+        return;
 
-	// TODO: Implement this
+    // TODO: Implement this
 }
 
 void CVif::MSCAL(VifUnit_Base* unit, const VifcodeInstruction inst)
@@ -197,10 +202,11 @@ void CVif::MSCNT(VifUnit_Base* unit, const VifcodeInstruction inst)
 
 void CVif::MSCALF(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
-	// VIF1 only
-	if (unit->core_id != 1) return;
+    // VIF1 only
+    if (unit->core_id != 1)
+        return;
 
-	// TODO: Implement this
+    // TODO: Implement this
 }
 
 void CVif::STMASK(VifUnit_Base* unit, const VifcodeInstruction inst)
@@ -221,18 +227,20 @@ void CVif::MPG(VifUnit_Base* unit, const VifcodeInstruction inst)
 
 void CVif::DIRECT(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
-	// VIF1 only
-	if (unit->core_id != 1) return;
+    // VIF1 only
+    if (unit->core_id != 1)
+        return;
 
-	// TODO: Implement this
+    // TODO: Implement this
 }
 
 void CVif::DIRECTHL(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
-	// VIF1 only
-	if (unit->core_id != 1) return;
+    // VIF1 only
+    if (unit->core_id != 1)
+        return;
 
-	// TODO: Implement this
+    // TODO: Implement this
 }
 
 void CVif::UNPACK(VifUnit_Base* unit, const VifcodeInstruction inst)

--- a/liborbum/src/Controller/Ee/Vpu/Vif/CVif.cpp
+++ b/liborbum/src/Controller/Ee/Vpu/Vif/CVif.cpp
@@ -1,3 +1,5 @@
+#include <boost/format.hpp>
+
 #include "Controller/Ee/Vpu/Vif/CVif.hpp"
 
 #include "Core.hpp"
@@ -99,13 +101,14 @@ void CVif::INSTRUCTION_UNSUPPORTED(VifUnit_Base* unit, const VifcodeInstruction 
 void CVif::NOP(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
     // nothing to do
+    return;
 }
 
 // Refer to EE Users Manual pg 104.
 void CVif::STCYCL(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
     // Writes CODE.IMMEDIATE to CYCLE
-    uword immediate = unit->code.IMMEDIATE.extract_from(unit->code.read_uword());
+    uword immediate = inst.imm();
     unit->cycle.write_uword(immediate);
 }
 
@@ -113,16 +116,17 @@ void CVif::STCYCL(VifUnit_Base* unit, const VifcodeInstruction inst)
 void CVif::OFFSET(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
     // VIF1 only
-    if (unit->core_id != 1)
+    if (unit->core_id != 1) {
+        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction") % unit->core_id);
         return;
+    }
 
     // Clear STAT.DBF
-    uword status = 0;
-    unit->stat.write_uword(unit->stat.DBF.insert_into(unit->stat.read_uword(), status));
+    unit->stat.insert_field(VifUnitRegister_Stat::DBF, 0);
 
     // Writes the lower 10 bits of CODE.IMMEDIATE to OFST
-    uword immediate = unit->code.IMMEDIATE.extract_from(unit->code.read_uword());
-    unit->ofst.write_uword(unit->ofst.OFFSET.extract_from(immediate));
+    uword immediate = inst.imm();
+    unit->ofst.insert_field(VifUnitRegister_Ofst::OFFSET, immediate);
 
     // Transfer BASE to TOPS
     unit->tops.write_uword(unit->base.read_uword());
@@ -132,53 +136,58 @@ void CVif::OFFSET(VifUnit_Base* unit, const VifcodeInstruction inst)
 void CVif::BASE(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
     // VIF1 only
-    if (unit->core_id != 1)
+    if (unit->core_id != 1) {
+        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction") % unit->core_id);
         return;
+    }
 
     // Writes the lower 10 bits of CODE.IMMEDIATE to BASE
-    uword immediate = unit->code.IMMEDIATE.extract_from(unit->code.read_uword());
-    unit->base.write_uword(unit->base.BASE.extract_from(immediate));
+    uword immediate = inst.imm();
+    unit->base.insert_field(VifUnitRegister_Base::BASE, immediate);
 }
 
 // Refer to EE Users Manual pg 107.
 void CVif::ITOP(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
-    uword immediate = unit->itops.ITOPS.extract_from(unit->code.read_uword());
-    unit->itops.write_uword(immediate);
+    uword immediate = inst.imm();
+    unit->itops.insert_field(VifUnitRegister_Itops::ITOPS, immediate);
 }
 
 // Refer to EE Users Manual pg 108.
 void CVif::STMOD(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
-    uword immediate = unit->mode.MOD.extract_from(unit->code.read_uword());
-    unit->mode.write_uword(immediate);
+    uword immediate = inst.imm();
+    unit->mode.insert_field(VifUnitRegister_Mode::MOD, immediate);
 }
 
 void CVif::MSKPATH3(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
     // VIF1 only
-    if (unit->core_id != 1)
+    if (unit->core_id != 1) {
+        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction") % unit->core_id);
         return;
+    }
 
-    // TODO: Implement this
+    // TODO: Implement this when GIF is implemented
 }
 
 void CVif::MARK(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
-    uword immediate = unit->mark.MARK.extract_from(unit->code.read_uword());
-    unit->mark.write_uword(immediate);
+    uword immediate = inst.imm();
+    unit->mark.insert_field(VifUnitRegister_Mark::MARK, immediate);
 }
 
 void CVif::FLUSHE(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
-    // TODO: Implement this
 }
 
 void CVif::FLUSH(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
     // VIF1 only
-    if (unit->core_id != 1)
+    if (unit->core_id != 1) {
+        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction") % unit->core_id);
         return;
+    }
 
     // TODO: Implement this
 }
@@ -186,8 +195,10 @@ void CVif::FLUSH(VifUnit_Base* unit, const VifcodeInstruction inst)
 void CVif::FLUSHA(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
     // VIF1 only
-    if (unit->core_id != 1)
+    if (unit->core_id != 1) {
+        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction") % unit->core_id);
         return;
+    }
 
     // TODO: Implement this
 }
@@ -203,8 +214,10 @@ void CVif::MSCNT(VifUnit_Base* unit, const VifcodeInstruction inst)
 void CVif::MSCALF(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
     // VIF1 only
-    if (unit->core_id != 1)
+    if (unit->core_id != 1) {
+        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction") % unit->core_id);
         return;
+    }
 
     // TODO: Implement this
 }
@@ -228,8 +241,10 @@ void CVif::MPG(VifUnit_Base* unit, const VifcodeInstruction inst)
 void CVif::DIRECT(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
     // VIF1 only
-    if (unit->core_id != 1)
+    if (unit->core_id != 1) {
+        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction") % unit->core_id);
         return;
+    }
 
     // TODO: Implement this
 }
@@ -237,8 +252,10 @@ void CVif::DIRECT(VifUnit_Base* unit, const VifcodeInstruction inst)
 void CVif::DIRECTHL(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
     // VIF1 only
-    if (unit->core_id != 1)
+    if (unit->core_id != 1) {
+        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction") % unit->core_id);
         return;
+    }
 
     // TODO: Implement this
 }

--- a/liborbum/src/Controller/Ee/Vpu/Vif/CVif.cpp
+++ b/liborbum/src/Controller/Ee/Vpu/Vif/CVif.cpp
@@ -95,48 +95,96 @@ void CVif::INSTRUCTION_UNSUPPORTED(VifUnit_Base* unit, const VifcodeInstruction 
     throw std::runtime_error("VIFcode CMD field was invalid! Please fix.");
 }
 
-void CVif::NOP(VifUnit_Base* unit, const VifcodeInstruction inst)
+// Refer to EE Users Manual pg 103.
+void CVif::NOP(VifUnit_Base * unit, const VifcodeInstruction inst)
 {
+	// nothing to do
 }
 
-void CVif::STCYCL(VifUnit_Base* unit, const VifcodeInstruction inst)
+// Refer to EE Users Manual pg 104.
+void CVif::STCYCL(VifUnit_Base * unit, const VifcodeInstruction inst)
 {
+	// Writes CODE.IMMEDIATE to CYCLE
+	uword immediate = unit->code.IMMEDIATE.extract_from(unit->code.read_uword());
+	unit->cycle.write_uword(immediate);
 }
 
-void CVif::OFFSET(VifUnit_Base* unit, const VifcodeInstruction inst)
+// Refer to EE Users Manual pg 105.
+void CVif::OFFSET(VifUnit_Base * unit, const VifcodeInstruction inst)
 {
+	// VIF1 only
+	if (unit->core_id != 1) return;
+
+	// Clear STAT.DBF
+	uword status = 0;
+	unit->stat.write_uword(unit->stat.DBF.insert_into(unit->stat.read_uword(), status));
+	
+	// Writes the lower 10 bits of CODE.IMMEDIATE to OFST
+	uword immediate = unit->code.IMMEDIATE.extract_from(unit->code.read_uword());
+	unit->ofst.write_uword(unit->ofst.OFFSET.extract_from(immediate));
+
+	// Transfer BASE to TOPS
+	unit->tops.write_uword(unit->base.read_uword());
 }
 
-void CVif::BASE(VifUnit_Base* unit, const VifcodeInstruction inst)
+// Refer to EE Users Manual pg 106.
+void CVif::BASE(VifUnit_Base * unit, const VifcodeInstruction inst)
 {
+	// VIF1 only
+	if (unit->core_id != 1) return;
+
+	// Writes the lower 10 bits of CODE.IMMEDIATE to BASE
+	uword immediate = unit->code.IMMEDIATE.extract_from(unit->code.read_uword());
+	unit->base.write_uword(unit->base.BASE.extract_from(immediate));
 }
 
-void CVif::ITOP(VifUnit_Base* unit, const VifcodeInstruction inst)
+// Refer to EE Users Manual pg 107.
+void CVif::ITOP(VifUnit_Base * unit, const VifcodeInstruction inst)
 {
+	uword immediate = unit->itops.ITOPS.extract_from(unit->code.read_uword());
+	unit->itops.write_uword(immediate);
 }
 
-void CVif::STMOD(VifUnit_Base* unit, const VifcodeInstruction inst)
+// Refer to EE Users Manual pg 108.
+void CVif::STMOD(VifUnit_Base * unit, const VifcodeInstruction inst)
 {
+	uword immediate = unit->mode.MOD.extract_from(unit->code.read_uword());
+	unit->mode.write_uword(immediate);
 }
 
 void CVif::MSKPATH3(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
+	// VIF1 only
+	if (unit->core_id != 1) return;
+
+	// TODO: Implement this
 }
 
 void CVif::MARK(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
+	uword immediate = unit->mark.MARK.extract_from(unit->code.read_uword());
+	unit->mark.write_uword(immediate);
 }
 
 void CVif::FLUSHE(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
+	// TODO: Implement this
 }
 
 void CVif::FLUSH(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
+	// VIF1 only
+	if (unit->core_id != 1) return;
+
+	// TODO: Implement this
 }
 
 void CVif::FLUSHA(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
+	// VIF1 only
+	if (unit->core_id != 1) return;
+
+	// TODO: Implement this
 }
 
 void CVif::MSCAL(VifUnit_Base* unit, const VifcodeInstruction inst)
@@ -149,6 +197,10 @@ void CVif::MSCNT(VifUnit_Base* unit, const VifcodeInstruction inst)
 
 void CVif::MSCALF(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
+	// VIF1 only
+	if (unit->core_id != 1) return;
+
+	// TODO: Implement this
 }
 
 void CVif::STMASK(VifUnit_Base* unit, const VifcodeInstruction inst)
@@ -169,10 +221,18 @@ void CVif::MPG(VifUnit_Base* unit, const VifcodeInstruction inst)
 
 void CVif::DIRECT(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
+	// VIF1 only
+	if (unit->core_id != 1) return;
+
+	// TODO: Implement this
 }
 
 void CVif::DIRECTHL(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
+	// VIF1 only
+	if (unit->core_id != 1) return;
+
+	// TODO: Implement this
 }
 
 void CVif::UNPACK(VifUnit_Base* unit, const VifcodeInstruction inst)

--- a/liborbum/src/Controller/Ee/Vpu/Vif/CVif.cpp
+++ b/liborbum/src/Controller/Ee/Vpu/Vif/CVif.cpp
@@ -117,7 +117,7 @@ void CVif::OFFSET(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
     // VIF1 only
     if (unit->core_id != 1) {
-        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction") % unit->core_id);
+        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction: OFFSET") % unit->core_id);
         return;
     }
 
@@ -137,7 +137,7 @@ void CVif::BASE(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
     // VIF1 only
     if (unit->core_id != 1) {
-        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction") % unit->core_id);
+        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction: BASE") % unit->core_id);
         return;
     }
 
@@ -164,7 +164,7 @@ void CVif::MSKPATH3(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
     // VIF1 only
     if (unit->core_id != 1) {
-        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction") % unit->core_id);
+        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction: MSKPATH3") % unit->core_id);
         return;
     }
 
@@ -185,7 +185,7 @@ void CVif::FLUSH(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
     // VIF1 only
     if (unit->core_id != 1) {
-        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction") % unit->core_id);
+        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction: FLUSH") % unit->core_id);
         return;
     }
 
@@ -196,7 +196,7 @@ void CVif::FLUSHA(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
     // VIF1 only
     if (unit->core_id != 1) {
-        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction") % unit->core_id);
+        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction: FLUSHA") % unit->core_id);
         return;
     }
 
@@ -215,7 +215,7 @@ void CVif::MSCALF(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
     // VIF1 only
     if (unit->core_id != 1) {
-        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction") % unit->core_id);
+        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction: MSCALF") % unit->core_id);
         return;
     }
 
@@ -242,7 +242,7 @@ void CVif::DIRECT(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
     // VIF1 only
     if (unit->core_id != 1) {
-        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction") % unit->core_id);
+        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction: DIRECT") % unit->core_id);
         return;
     }
 
@@ -253,7 +253,7 @@ void CVif::DIRECTHL(VifUnit_Base* unit, const VifcodeInstruction inst)
 {
     // VIF1 only
     if (unit->core_id != 1) {
-        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction") % unit->core_id);
+        BOOST_LOG(Core::get_logger()) << str(boost::format("Warning: VIF%d called a VIF1-only instruction: DIRECTHL") % unit->core_id);
         return;
     }
 

--- a/liborbum/src/Resources/Ee/Vpu/Vif/VifUnits.hpp
+++ b/liborbum/src/Resources/Ee/Vpu/Vif/VifUnits.hpp
@@ -33,7 +33,7 @@ public:
     VifUnitRegister_Ofst ofst;
     VifUnitRegister_Top top;
     VifUnitRegister_Tops tops;
-    VifUnitRegister_Mask mark;
+    VifUnitRegister_Mark mark;
     VifUnitRegister_Num num;
     VifUnitRegister_Code code;
     VifUnitRegister_Stat stat;


### PR DESCRIPTION
Some comments are really needed for this PR (haven't touched C++ for quite a while, so the code might be buggy or something)

VIF Instructions implemented:
* NOP
* STCYCL
* OFFSET
* BASE
* ITOP
* STMOD
* MARK

VIF1 check (since some instructions are VIF1-only) added for:
* MSKPATH3
* FLUSH
* FLUSHA
* MSCALF
* DIRECT
* DIRECTHL

The unmentioned instructions are untouched. I would like to finish the rest (save for the microprograms, I am still researching them)... but I'll be pretty busy for the next week or so.