### PR TITLE
Fix float reading and writing

### DIFF
--- a/liborbum/src/Common/Types/Register/QwordRegister.hpp
+++ b/liborbum/src/Common/Types/Register/QwordRegister.hpp
@@ -27,12 +27,14 @@ public:
     /// Read/write floats - wrappers around read/write uword.
     f32 read_float(const size_t offset)
     {
-        return static_cast<f32>(read_uword(offset));
+        uword raw = read_uword(offset);
+        return *reinterpret_cast<f32*>(&raw);
     }
 
     void write_float(const size_t offset, const f32 value)
     {
-        write_uword(offset, static_cast<uword>(value));
+        f32 raw = value;
+        write_uword(offset, *reinterpret_cast<uword*>(&raw));
     }
 
     /// ByteBusMappable overrides.

--- a/liborbum/src/Common/Types/Register/WordRegister.hpp
+++ b/liborbum/src/Common/Types/Register/WordRegister.hpp
@@ -24,12 +24,14 @@ public:
     /// Read/write floats - wrappers around read/write uword.
     f32 read_float()
     {
-        return static_cast<f32>(read_uword());
+        uword raw = read_uword();
+        return *reinterpret_cast<f32*>(&raw);
     }
 
     void write_float(const f32 value)
     {
-        write_uword(static_cast<uword>(value));
+        f32 raw = value;
+        write_uword(*reinterpret_cast<uword*>(&raw));
     }
 
     /// Bitfield extraction/insertion.


### PR DESCRIPTION
The current behaviour ignores the fractional part of a f32, meaning that floats such as `100.5` gets converted into `100` when it is saved into the registers.

This PR can be closed if it's wrong.